### PR TITLE
add support for stm32h503

### DIFF
--- a/scripts/stm32.script
+++ b/scripts/stm32.script
@@ -36,7 +36,8 @@ STMICRO <- [
 
 ["M33", [["u5", [ 0x455, 0x476, 0x481, 0x482 ]],
          ["l5", [ 0x472 ]],
-         ["h5", [ 0x484 ]]]]
+         ["h5", [ 0x484 ]],
+         ["h503", [ 0x474 ]]]]
 ]
 
 // The register scan list for the CPU ID

--- a/scripts/stmicro/stm32h503.script
+++ b/scripts/stmicro/stm32h503.script
@@ -1,0 +1,80 @@
+/////////////////////////////////////////////////////
+//
+//                   STM32H5x
+//
+
+/////////////////////////////////////////////////////
+//
+//   Memory map template of this device(s)
+//   Avoid unnecessary spaces.
+//
+
+//*************************************************************
+//*****             Memory map of the H5                   ****
+//*************************************************************
+const mem_template_H5 = @@"
+<?xml version=\"1.0\"?>
+<memory-map>
+  <memory type=\"ram\" start=\"0x00000000\" length=\"0x08000000\"/>
+  <memory type=\"flash\" start=\"0x08000000\" length=\"0x%x\">
+    <property name=\"blocksize\">0x%x</property>
+    <property name=\"secstart\">0</property>
+  </memory>
+  <memory type=\"ram\" start=\"0x%x\" length=\"0xf7fdffff\"/>
+</memory-map>"
+
+
+/////////////////////////////////////////////////////
+//
+//  Entry point of this script called by parent script
+//
+//      Remark: The intrfApi is a global object from parent
+//
+function stm32_device()
+{
+    local flash_size
+    local page_size
+    local ram_size
+
+    // Get the flash size in KB
+    _n_throw(intrfApi.readMem32(0x08fff80c))
+    flash_size = (intrfApi.value32 &0xFFFF) *1024
+
+    // Set the memory map according the device ID
+      local deviceStr
+      switch(deviceId) {
+
+        case 0x474 : // CHIPID_STM32H503
+            deviceStr = "H503"
+            ram_size = 0x8000 // 32KB
+            page_size = 0x2000 // 8k
+            break
+
+        default:
+            throw ERROR_NOT_FOUND
+    }
+
+    // Inform user of the device found
+    printf("STmicro family : STM32%s\n", deviceStr)
+
+    // Inform the user
+    printf("Detected FLASH : %dKB\nConfigured RAM : %dKB\n", flash_size/1024, ram_size/1024)
+
+    // The user specified the size of flash memory
+    if (isScriptObject("FLASH_SIZE") && FLASH_SIZE>0){
+      printf("CLI set  FLASH : %dKB\n", FLASH_SIZE)
+      flash_size = (FLASH_SIZE & 0xffff) * 1024
+    }
+
+    // The user specified the size of ram memory
+    if (isScriptObject("RAM_SIZE") && RAM_SIZE>0){
+      printf("CLI set    RAM : %dKB\n", RAM_SIZE)
+      ram_size = (RAM_SIZE & 0xffff) * 1024
+    }
+
+    DeviceAPI().memmap(format( mem_template_H5, flash_size, page_size, 0x08000000 + flash_size))
+
+    // Include flash loader script
+    require("stmicro/flash/h5.script")
+}
+

--- a/scripts/stmicro/stm32h503.script
+++ b/scripts/stmicro/stm32h503.script
@@ -20,7 +20,7 @@ const mem_template_H5 = @@"
     <property name=\"blocksize\">0x%x</property>
     <property name=\"secstart\">0</property>
   </memory>
-  <memory type=\"ram\" start=\"0x%x\" length=\"0xf7fdffff\"/>
+  <memory type=\"ram\" start=\"0x%x\" length=\"0x%x\"/>
 </memory-map>"
 
 
@@ -72,7 +72,7 @@ function stm32_device()
       ram_size = (RAM_SIZE & 0xffff) * 1024
     }
 
-    DeviceAPI().memmap(format( mem_template_H5, flash_size, page_size, 0x08000000 + flash_size))
+    DeviceAPI().memmap(format( mem_template_H5, flash_size, page_size, 0x08000000 + flash_size, 0xffffffff - 0x08000000 - flash_size))
 
     // Include flash loader script
     require("stmicro/flash/h5.script")


### PR DESCRIPTION
Added support for STM32H503
There seems to be some kind of support for STM32H5x3 devices with [scripts/stmicro/stm32h5.script](https://github.com/EmBitz/EBlink-scripts/blob/9025d67a7e921e48b850fb2e6ee62344b77ce86d/scripts/stmicro/stm32h5.script)
But it only defines device id 0x484 and has a different memory map/configuration.
The STM32H503 is device id 0x474.

I copied the file from stm32h5.script and added the memory map which is also configured in STM32CubeIDE. This seems to work, at least for my project. Correct me if i am wrong, but I don't think a more granular memory map file is required here.

STM32CubeIDE included configuration read with `info mem`:
![image](https://github.com/EmBitz/EBlink-scripts/assets/9519217/ed745e80-3049-40f1-911d-13da497302b6)

resulting memory configuration with eblink and the new script read with `info mem`:
![image](https://github.com/EmBitz/EBlink-scripts/assets/9519217/657c0901-5a8d-4691-8abb-27e5a136d3b7)

