### PR TITLE
H523/H533/H562/H563/H573 - complete current STM H5 Lineup

### DIFF
--- a/scripts/stm32.script
+++ b/scripts/stm32.script
@@ -36,7 +36,7 @@ STMICRO <- [
 
 ["M33", [["u5", [ 0x455, 0x476, 0x481, 0x482 ]],
          ["l5", [ 0x472 ]],
-         ["h5", [ 0x474, 0x484 ]]]]
+         ["h5", [ 0x474, 0x478, 0x484 ]]]]
 ]
 
 // The register scan list for the CPU ID

--- a/scripts/stmicro/stm32h5.script
+++ b/scripts/stmicro/stm32h5.script
@@ -57,9 +57,15 @@ function stm32_device()
             page_size = 0x2000
             break
 
-        case 0x484 : // CHIPID_STM32H563
-            deviceStr = "H563"
-            ram_size = 0x40000 // 256KB
+        case 0x478 : // CHIPID_STM32H523/H533
+            deviceStr = "H523/H533"
+            ram_size = 0x44000 // 272KB
+            page_size = 0x2000
+            break
+
+        case 0x484 : // CHIPID_STM32H562/H563/H573
+            deviceStr = "H562/H563/H573"
+            ram_size = 0xa0000 // 640k
             page_size = 0x2000
             break
 


### PR DESCRIPTION
Hi,
I got a few more H5 configurations. I have tested it with the H563ZI for now.
I will also receive a H533RE to test on in the next days. I suggest we stall this PR until i can test this too.
But I wanted to note it now.

This will complete the latest H5 lineup of stm32.
As far as I understand, there are no H5 configurations which have been left out after this.
[rm0481](https://www.st.com/resource/en/reference_manual/rm0481-stm32h52333xx-stm32h56263xx-and-stm32h573xx-armbased-32bit-mcus-stmicroelectronics.pdf) covers all of H523/H533/H562/H563/H573 processors.
The deviceIDs are noted in **59.12.4 DBGMCU registers** - `DBGMCU_IDCODE` on page **3116-3117**

The naming scheme is a bit tricky for H5 because H523/H533 are similar to each other, but different to H56x/573.
I just list them now, but I am not sure if you have something different in mind for the deviceStr. Im happy to get your input on that.

Also, i corrected the ram size for H562/H563/H573.

Furthermore, I had only a quick glance over the memory map in the manual, and it seems to roughly fit. If you want to check it more deeply, I am happy to also generate the memory maps from STMcubeIDE again.

Thanks in advance